### PR TITLE
removed unneeded brew cargo install, forced xquartz for vim, fixed incorrect .osx file paths to .setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ to manage packages
     * [Ruby](bin/scripts/ruby.bash)
     * [Rust](bin/scripts/rust.bash)
 3. Uses [Homebrew Cask](bin/scripts/brew-cask.bash) to install Mac applications (optional)
-4. Copies my [dotfiles](bin/dotfiles) to the home directory
+4. Copies my [dotfiles](bin/dotfiles) to the home directory and creates a `.env` file for sensitive info
 5. Creates an SSH key and adds it to the macOS Keychain (optional)
 6. Sets up the [Vim](bin/scripts/vim.bash) editor for development (optional)
 7. Changes the `Terminal.app` [theme](bin/scripts/terminal.bash) (optional)

--- a/bin/scripts/rust.bash
+++ b/bin/scripts/rust.bash
@@ -6,5 +6,3 @@
 # --------
 
 brew_install rust
-
-brew cask install cargo

--- a/bin/scripts/terminal.bash
+++ b/bin/scripts/terminal.bash
@@ -26,7 +26,7 @@ tell application "Terminal"
     (* Open the custom theme so that it gets added to the list
        of available terminal themes (note: this will open two
        additional terminal windows). *)
-    do shell script "open '$HOME/.osx/bin/themes/" & themeName & ".terminal'"
+    do shell script "open '$HOME/.setup/bin/themes/" & themeName & ".terminal'"
 
     (* Wait a little bit to ensure that the custom theme is added. *)
     delay 1

--- a/bin/scripts/vim.bash
+++ b/bin/scripts/vim.bash
@@ -25,6 +25,10 @@ PACKAGES=(
 
 log -v "configuring vim..."
 
+if [ ! -d /usr/local/Caskroom/xquartz ]; then
+    brew cask install xquartz
+fi
+
 brew install vim --with-lua --with-client-server --with-override-system-vi
 
 if [ -d ~/.vim ]; then

--- a/bin/utils/helpers.bash
+++ b/bin/utils/helpers.bash
@@ -82,7 +82,7 @@ function os_eligible() {
 #   -l level    log level: INFO, WARN, ERROR
 #
 function log() {
-    logfile=$(pwd)/.osx.log
+    logfile=$(pwd)/.setup.log
     verbose=0
     level="INFO"
 


### PR DESCRIPTION
# Submit a pull request

Replace any "X" below to describe your changes. Please check the boxes here by
inserting an "x" to confirm that your pull request meets the requirements:

- [ x] This pull request isn't a duplicate of an [existing one][1]
- [ x] No existing features have been broken
- [ x] Commit messages are detailed
- [x ] The [code style guidelines][2] have been followed
- [x ] Documentation has been updated to reflect changes
- [ ] Tests have been added / updated to reflect changes

Any questions should be directed to @tylucaskelley.

---

### What changes does this pull request make?

1. Since rust already installs cargo, the unneeded `brew cask install cargo` line was removed
2. Fixed a few references from ~/.osx to ~/.setup
3. Made sure XQuartz is installed before vim install

### What is the current behavior?

None of what I just mentioned. Buggy behavior.

### Does this pull request introduce any breaking changes?

No

### Other relevant information:

N/A

[1]: https://github.com/tylucaskelley/setup.sh/pulls
[2]: https://github.com/tylucaskelley/setup.sh/blob/master/.github/CONTRIBUTING.md#code-style
